### PR TITLE
Add missing utility CSS classes

### DIFF
--- a/pond.html
+++ b/pond.html
@@ -496,6 +496,20 @@
     .font-medium { font-weight: 500; }
     .font-semibold { font-weight: 600; }
     .font-bold { font-weight: 700; }
+    .flex { display: flex; }
+    .flex-col { flex-direction: column; }
+    .flex-row { flex-direction: row; }
+    .items-center { align-items: center; }
+    .justify-center { justify-content: center; }
+    .justify-between { justify-content: space-between; }
+    .mx-auto { margin-left: auto; margin-right: auto; }
+    .hidden { display: none; }
+    .block { display: block; }
+    .inline-block { display: inline-block; }
+    .inline-flex { display: inline-flex; }
+    .cursor-pointer { cursor: pointer; }
+    .space-y-2 > * + * { margin-top: 0.5rem; }
+    .space-x-2 > * + * { margin-left: 0.5rem; }
     .text-center { text-align: center; }
     .text-white { color: #ffffff; }
     .text-gray-300 { color: #d1d5db; }


### PR DESCRIPTION
## Summary
- restore commonly used utility styles that went missing after dropping Tailwind

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d0bac87c8320817842c6133e0b3b