### PR TITLE
Fix duplicate BN prediction redraw on resize

### DIFF
--- a/pond.html
+++ b/pond.html
@@ -4009,7 +4009,8 @@ function displayPastRunDetails(runIndex) {
           if (cumulativeGraphCanvas.clientHeight > 0) cumulativeGraphCanvas.height = cumulativeGraphCanvas.clientHeight;
           if (bnPredictionGraphCanvas && bnPredictionGraphCanvas.clientWidth > 0) bnPredictionGraphCanvas.width = bnPredictionGraphCanvas.clientWidth;
           if (bnPredictionGraphCanvas && bnPredictionGraphCanvas.clientHeight > 0) bnPredictionGraphCanvas.height = bnPredictionGraphCanvas.clientHeight;
-          drawPopulationGraph(); drawCumulativeGraph(); drawBNPredictionGraph();
+          drawPopulationGraph();
+          drawCumulativeGraph();
           if (bnPredictionGraphCanvas) drawBNPredictionGraph();
         }
       } else { // If past runs view is active


### PR DESCRIPTION
## Summary
- tweak resize handler to only call `drawBNPredictionGraph()` once

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d5f46ec483208d720bad39cc0fd8