### PR TITLE
Adaptive autopilot weights

### DIFF
--- a/pond.html
+++ b/pond.html
@@ -3318,13 +3318,17 @@ function updateCurrentBNPredictionsDisplay() {
       const SCORE_WEIGHT_GROWTH_BONUS = 1200;
       const SCORE_WEIGHT_ALL_GROWTH_BONUS_FACTOR = 2.2;
 
-      const GP_MEAN_WEIGHT_BASE = 0.40;
-      const UCB_BONUS_WEIGHT_BASE = 0.20;
-      const BN_SCORE_WEIGHT_BASE = 0.40;
-      const bnErr = getBnErrorAverage();
-      const BN_SCORE_WEIGHT = BN_SCORE_WEIGHT_BASE * Math.max(0, 1 - bnErr);
-      const GP_MEAN_WEIGHT = GP_MEAN_WEIGHT_BASE * (1 - bnErr * 0.5);
-      const UCB_BONUS_WEIGHT = UCB_BONUS_WEIGHT_BASE * (1 + bnErr * 0.5);
+      function computeAdaptiveWeights() {
+        const modelUnc = clamp(autoPilotStats.modelUncertainty ?? 0, 0, 1);
+        const bnAvgErr = clamp(autoPilotStats.bnPredictionErrorAvg ?? 0.5, 0, 1);
+        return {
+          gp: 0.40 * (1 - modelUnc),
+          ucb: 0.20 * (1 + modelUnc),
+          bn: 0.40 * Math.max(0, 1 - bnAvgErr)
+        };
+      }
+
+      const { gp: GP_MEAN_WEIGHT, ucb: UCB_BONUS_WEIGHT, bn: BN_SCORE_WEIGHT } = computeAdaptiveWeights();
 
       candidates.forEach(c => {
         let gpMean = 0;
@@ -3394,7 +3398,7 @@ function updateCurrentBNPredictionsDisplay() {
       };
 
 
-      console.log(`Autopilot selected (Source: ${bestCandidate.source}). Top Score: ${bestCandidate.score.toFixed(0)}. BN Weight: ${BN_SCORE_WEIGHT.toFixed(2)} GPW:${GP_MEAN_WEIGHT.toFixed(2)} UCBW:${UCB_BONUS_WEIGHT.toFixed(2)}. Stagnation: ${autoPilotStats.stagnationCounter}, ModelUncert: ${autoPilotStats.modelUncertainty.toFixed(2)}, Exploration: ${explorationFactor.toFixed(2)}, Kappa: ${KAPPA_UCB.toFixed(2)}`);
+      console.log(`Autopilot selected (Source: ${bestCandidate.source}). Top Score: ${bestCandidate.score.toFixed(0)}. Weights -> BN:${BN_SCORE_WEIGHT.toFixed(2)} GP:${GP_MEAN_WEIGHT.toFixed(2)} UCB:${UCB_BONUS_WEIGHT.toFixed(2)}. Stag:${autoPilotStats.stagnationCounter}, ModelUncert:${autoPilotStats.modelUncertainty.toFixed(2)} BNErr:${autoPilotStats.bnPredictionErrorAvg.toFixed(3)}, Exploration:${explorationFactor.toFixed(2)}, Kappa:${KAPPA_UCB.toFixed(2)}`);
 
       console.log(`  GP Pred: Mean=${bestCandidate.debug_gp_mean.toFixed(0)}, Var=${bestCandidate.debug_gp_variance.toFixed(3)}. BN Comp: ${bestCandidate.debug_bn_component.toFixed(0)}`);
       if (bnPredictionsForNextRun.extinction && bnPredictionsForNextRun.growth && bnPredictionsForNextRun.starvationRisk) {


### PR DESCRIPTION
## Summary
- add `computeAdaptiveWeights` in `suggestNextParameters`
- scale GP, UCB and BN weights with model uncertainty and BN error
- log the adaptive weights during autopilot runs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68424cc3301883208e164b3303fce728