### PR TITLE
Optimize quadtree updates

### DIFF
--- a/pond.html
+++ b/pond.html
@@ -2207,6 +2207,7 @@ function updateCurrentBNPredictionsDisplay() {
     function normalizeAngle(angle) { while (angle > Math.PI) angle -= 2 * Math.PI; while (angle < -Math.PI) angle += 2 * Math.PI; return angle; }
     function clamp(val, min, max) { return Math.min(Math.max(val, min), max); }
     function weightedRandomSelect(options) { if (!options || options.length === 0) return null; const totalWeight = options.reduce((sum, option) => sum + Math.max(0, option.weight), 0); if (totalWeight <= 0) { return options.length > 0 ? options[randomInt(0, options.length - 1)].item : null; } let randomVal = Math.random() * totalWeight; for (const option of options) { const currentWeight = Math.max(0, option.weight); if (randomVal < currentWeight) return option.item; randomVal -= currentWeight; } return options.length > 0 ? options[options.length - 1].item : null; }
+    function isInCurrentNode(entity) { return entity._qtNode && entity._qtNode.contains(entity.pos.x, entity.pos.y); }
 
     function parseHslString(hslString) {
       if (!hslString || typeof hslString !== 'string') return null;
@@ -2338,7 +2339,9 @@ function updateCurrentBNPredictionsDisplay() {
           this.vel.limit(this.maxSpeed);
           this.pos.add(this.vel);
           this.keepInBounds();
-          quadtree.update(this);
+          if (!isInCurrentNode(this)) {
+            quadtree.update(this);
+          }
         }
         return true; // Still in simulation
       }


### PR DESCRIPTION
## Summary
- add `isInCurrentNode` helper to check if an entity is still inside its quadtree node
- update `Entity.update` to only refresh quadtree location when necessary

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684311fd2afc832099ee17a7430d0006